### PR TITLE
Provide support for additional systems

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,7 +18,23 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,12 +1,25 @@
 {
-  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-
-  outputs = { self, nixpkgs }: {
-    overlay = final: prev: {
-      opam2json = final.ocamlPackages.callPackage ./opam2json.nix { };
-    };
-    packages.x86_64-linux.opam2json =
-      (nixpkgs.legacyPackages.x86_64-linux.extend self.overlay).opam2json;
-    defaultPackage.x86_64-linux = self.packages.x86_64-linux.opam2json;
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    systems.url = "github:nix-systems/default";
   };
+
+  outputs = { self, systems, nixpkgs }:
+    let
+      eachSystem = nixpkgs.lib.genAttrs (import systems);
+    in
+    {
+      overlay = final: prev: {
+        opam2json = final.ocamlPackages.callPackage ./opam2json.nix { };
+      };
+
+      packages = eachSystem (system:
+        let
+          opam2json = (nixpkgs.legacyPackages.${system}.extend self.overlay).opam2json;
+        in
+        {
+          inherit opam2json;
+          default = opam2json;
+        });
+    };
 }


### PR DESCRIPTION
I was attempting to fix a error when running `nix flake show` on a flake that used `opam-nix`, and saw that this flake was hard-coded to support `x86_64-linux`. It turns out that this was not the issue, but I thought I might submit the PR anyway in case it’s of any use. Feel free to close this if it isn’t.

I used [nix-systems/default](https://github.com/nix-systems/default) – I believe people are moving away from `flake-utils`, which seems to use this under the hood as of https://github.com/numtide/flake-utils/commit/1c226cc8c6562379ffd0ac36ca095396250d94d7. Because the list of systems is provided as an input, it can be easily overridden by consumers. For more information on this pattern there’s some documentation [in this repo](https://github.com/nix-systems/nix-systems).