### PR TITLE
refactor: update opam-file-format, cmdliner

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1640418986,
-        "narHash": "sha256-a8GGtxn2iL3WAkY5H+4E0s3Q7XJt6bTOvos9qqxT5OQ=",
-        "owner": "NixOS",
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5c37ad87222cfc1ec36d6cd1364514a9efc2f7f2",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
         "type": "github"
       },
       "original": {

--- a/opam2json.opam
+++ b/opam2json.opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "ocamlfind"
   "cmdliner" {>= "1.0.0"}
-  "opam-file-format" {>= "2.0.0" & < "2.1"}
+  "opam-file-format" {>= "2.0.0"}
   "yojson" {>= "1.7.0"}
 ]
 build: [

--- a/src/opam2json.ml
+++ b/src/opam2json.ml
@@ -94,12 +94,13 @@ let run files =
     try
       let txt = try string_of_channel stdin with Sys_error _ -> "" in
       let orig = OpamParser.string txt "/dev/stdin" in
-      print_file orig
+      print_file orig;
+      Cmd.Exit.ok
     with e ->
       fatal_exn e;
       Printf.eprintf "Error on input from stdin: %s\n"
         (Printexc.to_string e);
-      exit 10
+      Cmd.Exit.some_error
   else
   let ok =
     List.fold_left (fun ok file ->
@@ -114,18 +115,20 @@ let run files =
           false
       ) true files
   in
-  if not ok then exit 10
-
-let cmd =
-  Term.(pure run $ arg_files)
+  if ok then Cmd.Exit.ok else Cmd.Exit.some_error
 
 let man = []
 
 let main_cmd_info =
-  Term.info "opam2json" ~version:"0.1"
+  Cmd.info "opam2json" ~version:"0.1"
     ~doc:"A command-line utility to turn opam file format to json"
     ~man
 
+let cmd =
+  let open Cmdliner.Term.Syntax in
+  Cmd.make main_cmd_info @@
+    let+ arg_files in
+    run arg_files
+
 let () =
-  let r = Term.eval (cmd, main_cmd_info) in
-  Term.exit r
+  exit (Cmd.eval' cmd)


### PR DESCRIPTION
**Changes:**
- use newer `opam-file-format` (for https://github.com/tweag/opam-nix/pull/152)
- use newer `Cmdliner` (version restricted in `opam2json.opam` but not in `opam2json.nix`, so nix fetches latest on update) that has some breaking changes
  - return exit code 123 instead of 10 on error
  - use `Cmd.make` / `Cmd.eval'` API instead of the deprecated `Term.pure` / `Term.eval` / `Term.exit`